### PR TITLE
Fix In-Dollars Equity Trade Extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setting Up Email Fowarding:
 1. The user creates an account and is assigned a unique alphanumeric access key.
 2. The user sets up email forwarding filter(s) for the trade confirmation emails:
     - From Address: The Robinhood source email (noreply@robinhood.com). 
-    - To Address: The centralized collection email plus addressed with the user's access key (i.e., <local-part>+<access-key>@<domain>).
+    - To Address: The centralized collection email plus addressed with the user's access key (i.e., `<local-part>+<access-key>@<domain>`).
     - Subject: The expected subject line(s) of the trade confirmation emails.
   
 Email Processing:

--- a/src/Lionheart.Pipeline.Extractors/src/Equities/InDollarsEquityTradeExtractor.cs
+++ b/src/Lionheart.Pipeline.Extractors/src/Equities/InDollarsEquityTradeExtractor.cs
@@ -12,7 +12,7 @@ public sealed class InDollarsEquityTradeExtractor : BaseTradeExtractor<EquityTra
 
     /// <inheritdoc />
     protected override string Pattern => 
-        @"^Your market order to (buy|sell) \$([0-9,]+\.[0-9]+) of ([a-zA-Z\.]+) was executed on ([a-zA-Z]+ [0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} at [0-9]{1,2}:[0-9]{2} (?:AM|PM))\. You (?:paid|received) \$[0-9,]+\.[0-9]+ for ([0-9,\.]+) shares?, at an average price of \$([0-9,]+\.[0-9]+) per share\.$";
+        @"^Your (?:market )?order to (buy|sell) \$([0-9,]+\.[0-9]+) of ([a-zA-Z\.]+) was executed on ([a-zA-Z]+ [0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} at [0-9]{1,2}:[0-9]{2} (?:AM|PM))\. You (?:paid|received) \$[0-9,]+\.[0-9]+ for ([0-9,\.]+) shares?, at an average price of \$([0-9,]+\.[0-9]+) per share\.$";
 
     /// <inheritdoc />
     protected override string GetTradeDataSection(string emailBody)
@@ -23,7 +23,7 @@ public sealed class InDollarsEquityTradeExtractor : BaseTradeExtractor<EquityTra
         }
 
         // Find the start of the trade data section.
-        int tradeDataStartIndex = emailBody.IndexOf("Your market order to");
+        int tradeDataStartIndex = emailBody.IndexOf("Your ");
         if (tradeDataStartIndex == -1)
         {
             return string.Empty;
@@ -60,6 +60,7 @@ public sealed class InDollarsEquityTradeExtractor : BaseTradeExtractor<EquityTra
 
         return new EquityTradeDomainModel
         {
+            // Fractional trades can only be placed as market orders.
             OrderType = OrderType.Market,
             ExecutedAt = executedAt,
             TransactionType = transactionType,

--- a/src/Lionheart.Pipeline.Extractors/test/Equities/InDollarsEquityTradeExtractorTests.cs
+++ b/src/Lionheart.Pipeline.Extractors/test/Equities/InDollarsEquityTradeExtractorTests.cs
@@ -8,35 +8,83 @@ namespace Lionheart.Pipeline.Extractors.Equities;
 
 public class InDollarsEquityTradeExtractorTests
 {
-    [Fact]
-    public void Extract_WellFormedEmailBody_ShouldReturnExtractedEquityTrade()
+    #region Test Data
+    public static IEnumerable<object[]> WellFormedEmailBodyData()
+    {
+        yield return new object[]
+        {
+            new EmailInputDomainModel
+            {
+                Body = "abcdefg <div>"
+                    + "Your market order to buy $1,543.20 of ABC was executed on "
+                    + "March 21st, 2021 at 2:30 PM. You paid $1,543.20 for 1.25 shares, "
+                    + "at an average price of $1,234.56 per share."
+                    + "</div> abcdefg"
+            },
+            new EquityTradeDomainModel
+            {
+                OrderType = OrderType.Market,
+                ExecutedAt = new DateTime(2021, 3, 21, 14, 30, 0),
+                TransactionType = TransactionType.Open,
+                Quantity = 1.25m,
+                AveragePrice = 1234.56m,
+                Notional = 1543.20m,
+                Equity = new EquityDomainModel
+                {
+                    Ticker = "ABC"
+                }
+            }
+        };
+        yield return new object[]
+        {
+            new EmailInputDomainModel
+            {
+                Body = "abcdefg <div>"
+                    + "Your order to sell $1.25 of XYZ.A was executed on "
+                    + "September 2nd, 2021 at 11:45 AM. You paid $1.25 for 0.5 shares, "
+                    + "at an average price of $2.50 per share."
+                    + "</div> abcdefg"
+            },
+            new EquityTradeDomainModel
+            {
+                OrderType = OrderType.Market,
+                ExecutedAt = new DateTime(2021, 9, 2, 11, 45, 0),
+                TransactionType = TransactionType.Close,
+                Quantity = 0.5m,
+                AveragePrice = 2.50m,
+                Notional = 1.25m,
+                Equity = new EquityDomainModel
+                {
+                    Ticker = "XYZ.A"
+                }
+            }
+        };
+    }
+    #endregion Test Data
+
+    [Theory]
+    [MemberData(nameof(WellFormedEmailBodyData))]
+    public void Extract_WellFormedEmailBody_ShouldReturnExtractedEquityTrade(EmailInputDomainModel email, EquityTradeDomainModel expectedTrade)
     {
         // Arrange
-        var tradeData = "Your market order to buy " +
-            $"$1,543.20 of ABC was executed on " +
-            $"March 21st, 2021 at 2:30 PM. You paid $1,543.20 for 1.25 shares, " +
-            $"at an average price of $1,234.56 per share.";
-
-        var email = new EmailInputDomainModel { Body = $"abcdefg <div>{tradeData}</div> abcdefg" };
-
         var extractor = new InDollarsEquityTradeExtractor();
 
         // Act
-        EquityTradeDomainModel? trade = extractor.Extract(email);
+        EquityTradeDomainModel? actualTrade = extractor.Extract(email);
 
         // Assert
-        Assert.NotNull(trade);
+        Assert.NotNull(actualTrade);
 
-        Assert.Equal(OrderType.Market, trade!.OrderType);
-        Assert.Equal(new DateTime(2021, 3, 21, 14, 30, 0), trade.ExecutedAt);
-        Assert.Equal(TransactionType.Open, trade.TransactionType);
-        Assert.Equal(1.25m, trade.Quantity);
-        Assert.Equal(1234.56m, trade.AveragePrice);
-        Assert.Equal(1543.20m, trade.Notional);
+        Assert.Equal(expectedTrade.OrderType, actualTrade!.OrderType);
+        Assert.Equal(expectedTrade.ExecutedAt, actualTrade.ExecutedAt);
+        Assert.Equal(expectedTrade.TransactionType, actualTrade.TransactionType);
+        Assert.Equal(expectedTrade.Quantity, actualTrade.Quantity);
+        Assert.Equal(expectedTrade.AveragePrice, actualTrade.AveragePrice);
+        Assert.Equal(expectedTrade.Notional, actualTrade.Notional);
 
-        EquityDomainModel equity = trade.Equity;
+        EquityDomainModel equity = actualTrade.Equity;
         Assert.NotNull(equity);
-        Assert.Equal("ABC", equity.Ticker);
+        Assert.Equal(expectedTrade.Equity.Ticker, equity.Ticker);
     }
 
     [Theory]


### PR DESCRIPTION
Changes:
- Make the order type name optional in the trade data regex pattern.
- Clean up InDollarsEquityTradeExtractorTests.